### PR TITLE
Add basic 'build and test' script.

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,13 @@
+name: Test
+run-name: ${{ github.actor }} is checking they haven't broken anything
+on: [push]
+jobs:
+  Compile-And-Run-The-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Compile the code
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,6 +1,8 @@
 name: Test
 run-name: ${{ github.actor }} is checking they haven't broken anything
 on: [push]
+env:
+  CARGO_TERM_COLOR: always
 jobs:
   Compile-And-Run-The-Tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've run it atop the `14-parsing-a-vcf-file-headers-into-a-data-structure` branch to check that it works https://github.com/Rust-Wellcome/vcf-parser/actions/runs/4567995490 and also that it fails if the tests fail https://github.com/Rust-Wellcome/vcf-parser/actions/runs/4567314781

Note that some of the tests didn't seem to be picked up by the test runner. See the run for this commit https://github.com/Rust-Wellcome/vcf-parser/actions/runs/4567147383 . Whether this is due to the problems with this CI script or with the tests themselves I'm not sure, and will defer judgement to those with more rust experience.