### PR TITLE
Implement key-part of format validation.

### DIFF
--- a/vcf/src/lib.rs
+++ b/vcf/src/lib.rs
@@ -1,3 +1,5 @@
+mod validate_format;
+
 pub fn hello() {
     println!("Hello world!");
 }

--- a/vcf/src/validate_format.rs
+++ b/vcf/src/validate_format.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+/// - [X] Check has all and only required keys.
+/// - [ ] Check that values are of the required types.
+fn is_valid_format(input: HashMap<&str, &str>) -> bool {
+        let keys: HashSet<&str> = input.keys().copied().collect();
+        let required_key = HashSet::from(["ID", "Number", "Type", "Description"]);
+        return required_key == keys;
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn returns_true_when_all_fields_present_and_value_types_correct() {
+        let valid_input = HashMap::from([
+            ("ID", "ID123"),
+            ("Number", "3"),
+            ("Type", "String"),
+            ("Description", "This is a thing"),
+        ]);
+
+        let result = is_valid_format(valid_input);
+
+        assert_eq!(result, true);
+    }
+
+    #[test]
+    fn returns_false_if_missing_id() {
+        let missing_id_input = HashMap::from([
+            ("Number", "3"),
+            ("Type", "String"),
+            ("Description", "This is a thing"),
+        ]);
+
+        let result = is_valid_format(missing_id_input);
+
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn returns_false_if_missing_number() {
+        let missing_number_input = HashMap::from([
+            ("ID", "ID123"),
+            ("Type", "String"),
+            ("Description", "This is a thing"),
+        ]);
+
+        let result = is_valid_format(missing_number_input);
+
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn returns_false_if_missing_type() {
+        let missing_type_input = HashMap::from([
+            ("ID", "ID123"),
+            ("Number", "3"),
+            ("Description", "This is a thing"),
+        ]);
+
+        let result = is_valid_format(missing_type_input);
+
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn returns_false_if_missing_description() {
+        let missing_description_input = HashMap::from([
+            ("ID", "ID123"),
+            ("Number", "3"),
+            ("Type", "String"),
+        ]);
+
+        let result = is_valid_format(missing_description_input);
+
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn returns_false_if_extra_key_included() {
+        let extra_key_input = HashMap::from([
+            ("ID", "ID123"),
+            ("Number", "3"),
+            ("Type", "String"),
+            ("Description", "This is a thing"),
+            ("BadKey", "This shouldn't be here"),
+        ]);
+
+        let result = is_valid_format(extra_key_input);
+
+        assert_eq!(result, false);
+    }
+}


### PR DESCRIPTION
This is a partial implementation of a validator for the FORMAT meta-information lines. It only checks that the field names are correct. According to my reading of the spec, all of and only the following fields should be present.

    * ID
    * Number
    * Type
    * Description

See section 1.4.4 of the v4.4 specs.

The rest of the implementation will follow on a subsequent PR.

There's at least three things wrong with it:
* It's probably not very idiomatic Rust.
* It doesn't output any information as to _why_ the input isn't valid. 
* I'm not sure that parsing and then validating makes sense, perhaps it should be parsing all the way down?

Nevertheless, I think it's a good start. 