### PR TITLE
Return result

### DIFF
--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -1,5 +1,8 @@
 use std::io::Read;
 
+pub struct VCF;
+pub struct VCFError;
+
 /// Create a VCF object from a file.
 /// 
 /// ```
@@ -30,6 +33,11 @@ use std::io::Read;
 /// 20 1230237 . T . 47 PASS NS=3;DP=13;AA=T GT:GQ:DP:HQ 0|0:54:7:56,60 0|0:48:4:51,51 0/0:61:2
 /// 20 1234567 microsat1 GTC G,GTCT 50 PASS NS=3;DP=9;AA=G GT:GQ:DP 0/1:35:4 0/2:17:2 1/1:40:3
 /// "#;
-/// let vcf = parse_vcf(&vcf_source[..]);
+/// match parse_vcf(&vcf_source[..]) {
+///     Ok(vcf) => {assert!(true);}
+///     Err(err) => {assert!(false);}
+/// }
 /// ```
-pub fn parse_vcf(source: impl Read) {}
+pub fn parse_vcf(source: impl Read) ->  Result<VCF, VCFError> {
+    return Ok(VCF);
+}


### PR DESCRIPTION
This elaborates on the interface for the `parse_vcf` function, making the assumption it will return a `Result` type, with the success part being of `VCF` type.