### PR TITLE
Add `fileformat` attribute to returned object.

### DIFF
--- a/vcf/src/lib.rs
+++ b/vcf/src/lib.rs
@@ -1,6 +1,7 @@
 mod headers;
 mod parse;
 mod validate_format;
+mod validate_fileformat;
 pub mod vcf;
 
 pub use headers::*;

--- a/vcf/src/validate_fileformat.rs
+++ b/vcf/src/validate_fileformat.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::headers::Header;
 use crate::headers::HeaderValue::{Flat, Nested};
 
-fn is_valid_file_format(input: Header) -> bool {
+pub fn is_valid_file_format(input: &Header) -> bool {
     is_flat(&input)
     & key_is_fileformat(&input)
 }
@@ -26,18 +26,18 @@ mod tests {
     #[test]
     fn is_valid_if_key_is_fileformat() {
         let header = Header {key: "fileformat", value: Flat("VCFv4.4")};
-        assert_eq!(is_valid_file_format(header), true);
+        assert_eq!(is_valid_file_format(&header), true);
     }
 
     #[test]
     fn is_invalid_if_key_is_not_fileformat() {
         let header = Header {key: "gileformat", value: Flat("VCFv4.4")};
-        assert_eq!(is_valid_file_format(header), false);
+        assert_eq!(is_valid_file_format(&header), false);
     }
 
     #[test]
     fn is_invalid_if_header_value_nested() {
         let header = Header {key: "fileformat", value: Nested(HashMap::from([("another_key", "VCFv4.4")])) };
-        assert_eq!(is_valid_file_format(header), false);
+        assert_eq!(is_valid_file_format(&header), false);
     }
 }

--- a/vcf/src/validate_fileformat.rs
+++ b/vcf/src/validate_fileformat.rs
@@ -4,7 +4,19 @@ use crate::headers::Header;
 use crate::headers::HeaderValue::{Flat, Nested};
 
 fn is_valid_file_format(input: Header) -> bool {
-    return false;
+    is_flat(&input)
+    & key_is_fileformat(&input)
+}
+
+fn is_flat(input: &Header) -> bool {
+    match input.value {
+        Flat(..) => true,
+        _ => false,
+    }
+}
+
+fn key_is_fileformat(input: &Header) -> bool {
+    input.key == "fileformat"
 }
 
 #[cfg(test)]

--- a/vcf/src/validate_fileformat.rs
+++ b/vcf/src/validate_fileformat.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use crate::headers::Header;
+use crate::headers::HeaderValue::{Flat, Nested};
+
+fn is_valid_file_format(input: Header) -> bool {
+    return false;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_valid_if_key_is_fileformat() {
+        let header = Header {key: "fileformat", value: Flat("VCFv4.4")};
+        assert_eq!(is_valid_file_format(header), true);
+    }
+
+    #[test]
+    fn is_invalid_if_key_is_not_fileformat() {
+        let header = Header {key: "gileformat", value: Flat("VCFv4.4")};
+        assert_eq!(is_valid_file_format(header), false);
+    }
+
+    #[test]
+    fn is_invalid_if_header_value_nested() {
+        let header = Header {key: "fileformat", value: Nested(HashMap::from([("another_key", "VCFv4.4")])) };
+        assert_eq!(is_valid_file_format(header), false);
+    }
+}

--- a/vcf/src/validate_fileformat.rs
+++ b/vcf/src/validate_fileformat.rs
@@ -26,18 +26,18 @@ mod tests {
     #[test]
     fn is_valid_if_key_is_fileformat() {
         let header = Header {key: "fileformat", value: Flat("VCFv4.4")};
-        assert_eq!(is_valid_file_format(&header), true);
+        assert!(is_valid_file_format(&header));
     }
 
     #[test]
     fn is_invalid_if_key_is_not_fileformat() {
         let header = Header {key: "gileformat", value: Flat("VCFv4.4")};
-        assert_eq!(is_valid_file_format(&header), false);
+        assert!(!is_valid_file_format(&header));
     }
 
     #[test]
     fn is_invalid_if_header_value_nested() {
         let header = Header {key: "fileformat", value: Nested(HashMap::from([("another_key", "VCFv4.4")])) };
-        assert_eq!(is_valid_file_format(&header), false);
+        assert!(!is_valid_file_format(&header));
     }
 }

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -48,6 +48,42 @@ pub struct VCFError;
 /// assert_eq!(vcf.file_format, "VCFv4.4");
 ///# Ok::<(), VCFError>(())
 /// ```
+///
+/// On the other hand, if the file is invalid, for example because the file format attribute is
+/// missing, then the function will return a `VCFError` instance, highlighting the error.
+///
+/// ```
+/// use vcf::vcf::parse_vcf;
+/// let vcf_source = br#"##fileDate=20090805
+/// ###source=myImputationProgramV3.1
+/// ###reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
+/// ###contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+/// ###phasing=partial
+/// ###INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+/// ###INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+/// ###INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+/// ###INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+/// ###INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+/// ###INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+/// ###FILTER=<ID=q10,Description="Quality below 10">
+/// ###FILTER=<ID=s50,Description="Less than 50% of samples have data">
+/// ###FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+/// ###FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+/// ###FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+/// ###FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+/// ##CHROM POS ID REF ALT QUAL FILTER INFO FORMAT NA00001 NA00002 NA00003
+/// 20 14370 rs6054257 G A 29 PASS NS=3;DP=14;AF=0.5;DB;H2 GT:GQ:DP:HQ 0|0:48:1:51,51 1|0:48:8:51,51 1/1:43:5:.,.
+/// 20 17330 . T A 3 q10 NS=3;DP=11;AF=0.017 GT:GQ:DP:HQ 0|0:49:3:58,50 0|1:3:5:65,3 0/0:41:3
+/// 20 1110696 rs6040355 A G,T 67 PASS NS=2;DP=10;AF=0.333,0.667;AA=T;DB GT:GQ:DP:HQ 1|2:21:6:23,27 2|1:2:0:18,2 2/2:35:4
+/// 20 1230237 . T . 47 PASS NS=3;DP=13;AA=T GT:GQ:DP:HQ 0|0:54:7:56,60 0|0:48:4:51,51 0/0:61:2
+/// 20 1234567 microsat1 GTC G,GTCT 50 PASS NS=3;DP=9;AA=G GT:GQ:DP 0/1:35:4 0/2:17:2 1/1:40:3
+/// "#;
+/// use vcf::vcf::VCFError;
+/// match parse_vcf(&vcf_source[..]) {
+///     Err(VCFError) => assert!(true),
+///     _ => assert!(false),
+/// };
+/// ```
 pub fn parse_vcf(source: impl Read) ->  Result<VCF, VCFError> {
     let mut buf = BufReader::new(source);
     let mut first_line = String::new();

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -1,12 +1,20 @@
 use std::io::Read;
+use std::io::BufReader;
+use std::io::BufRead;
+use crate::Header;
+use crate::HeaderValue::Flat;
 
-pub struct VCF;
+pub struct VCF {
+    pub file_format: String,
+}
 #[derive(Debug)]
 pub struct VCFError;
 
 /// Create a VCF object from a file.
 ///
 /// Given a valid file, one can obtain an object continaing the VCF data.
+///
+/// For example, we can check the version of a vcf file as follows.
 /// 
 /// ```
 /// use vcf::vcf::parse_vcf;
@@ -36,9 +44,16 @@ pub struct VCFError;
 /// 20 1234567 microsat1 GTC G,GTCT 50 PASS NS=3;DP=9;AA=G GT:GQ:DP 0/1:35:4 0/2:17:2 1/1:40:3
 /// "#;
 ///# use vcf::vcf::VCFError;
-/// parse_vcf(&vcf_source[..])?;
+/// let vcf = parse_vcf(&vcf_source[..])?;
+/// assert_eq!(vcf.file_format, "VCFv4.4");
 ///# Ok::<(), VCFError>(())
 /// ```
 pub fn parse_vcf(source: impl Read) ->  Result<VCF, VCFError> {
-    return Ok(VCF);
+    let mut buf = BufReader::new(source);
+    let mut first_line = String::new();
+    buf.read_line(& mut first_line);
+    return match Header::parse(&first_line).unwrap().value {
+        Flat(s) => Ok(VCF {file_format: s.to_string()}),
+        _ => panic!(),
+    };
 }

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -1,9 +1,12 @@
 use std::io::Read;
 
 pub struct VCF;
+#[derive(Debug)]
 pub struct VCFError;
 
 /// Create a VCF object from a file.
+///
+/// Given a valid file, one can obtain an object continaing the VCF data.
 /// 
 /// ```
 /// use vcf::vcf::parse_vcf;
@@ -33,10 +36,9 @@ pub struct VCFError;
 /// 20 1230237 . T . 47 PASS NS=3;DP=13;AA=T GT:GQ:DP:HQ 0|0:54:7:56,60 0|0:48:4:51,51 0/0:61:2
 /// 20 1234567 microsat1 GTC G,GTCT 50 PASS NS=3;DP=9;AA=G GT:GQ:DP 0/1:35:4 0/2:17:2 1/1:40:3
 /// "#;
-/// match parse_vcf(&vcf_source[..]) {
-///     Ok(vcf) => {assert!(true);}
-///     Err(err) => {assert!(false);}
-/// }
+///# use vcf::vcf::VCFError;
+/// parse_vcf(&vcf_source[..])?;
+///# Ok::<(), VCFError>(())
 /// ```
 pub fn parse_vcf(source: impl Read) ->  Result<VCF, VCFError> {
     return Ok(VCF);

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -3,6 +3,7 @@ use std::io::BufRead;
 use crate::Header;
 use crate::HeaderValue::Flat;
 use crate::validate_fileformat::is_valid_file_format;
+use crate::parse;
 
 pub struct VCF {
     pub file_format: String,
@@ -17,6 +18,12 @@ pub enum VCFError {
 impl From<io::Error> for VCFError {
     fn from(error: io::Error) -> Self {
         VCFError::IoError(error)
+    }
+}
+
+impl From<parse::ParseError> for VCFError {
+    fn from(error: parse::ParseError) -> Self {
+        VCFError::ParseError
     }
 }
 

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -10,8 +10,7 @@ pub struct VCFError;
 /// 
 /// ```
 /// use vcf::vcf::parse_vcf;
-/// let vcf_source = br#"\
-/// ###fileformat=VCFv4.4
+/// let vcf_source = br#"##fileformat=VCFv4.4
 /// ###fileDate=20090805
 /// ###source=myImputationProgramV3.1
 /// ###reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -3,6 +3,7 @@ use std::io::BufReader;
 use std::io::BufRead;
 use crate::Header;
 use crate::HeaderValue::Flat;
+use crate::validate_fileformat::is_valid_file_format;
 
 pub struct VCF {
     pub file_format: String,
@@ -88,8 +89,13 @@ pub fn parse_vcf(source: impl Read) ->  Result<VCF, VCFError> {
     let mut buf = BufReader::new(source);
     let mut first_line = String::new();
     buf.read_line(& mut first_line);
-    return match Header::parse(&first_line).unwrap().value {
-        Flat(s) => Ok(VCF {file_format: s.to_string()}),
-        _ => panic!(),
-    };
+    let parsed = Header::parse(&first_line).unwrap();
+    if is_valid_file_format(&parsed) {
+        match parsed.value {
+            Flat(s) => Ok(VCF {file_format: s.to_string()}),
+            _ => panic!(),
+        }
+    } else {
+        Err(VCFError)
+    }
 }

--- a/vcf/src/vcf.rs
+++ b/vcf/src/vcf.rs
@@ -1,5 +1,3 @@
-use std::io::Read;
-use std::io::BufReader;
 use std::io::BufRead;
 use crate::Header;
 use crate::HeaderValue::Flat;
@@ -85,10 +83,8 @@ pub struct VCFError;
 ///     _ => assert!(false),
 /// };
 /// ```
-pub fn parse_vcf(source: impl Read) ->  Result<VCF, VCFError> {
-    let mut buf = BufReader::new(source);
-    let mut first_line = String::new();
-    buf.read_line(& mut first_line);
+pub fn parse_vcf(source: impl BufRead) ->  Result<VCF, VCFError> {
+    let first_line = source.lines().next().unwrap().expect("This should just bloody work");
     let parsed = Header::parse(&first_line).unwrap();
     if is_valid_file_format(&parsed) {
         match parsed.value {


### PR DESCRIPTION
This adds a `fileformat` attribute to the `VCF` object returned by `parse_vcf`.

See the docs [here](https://github.com/Rust-Wellcome/vcf-parser/compare/check-version?expand=1#diff-be126480a75a88c34f2b8e767687831356fda94dcb9425b67653e2e1a6d41aa6R30).

It's the first step towards adding all the header data.