### PR TITLE
Better parsing of header

### DIFF
--- a/vcf/Cargo.toml
+++ b/vcf/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex = "1.9.3"

--- a/vcf/Cargo.toml
+++ b/vcf/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 regex = "1.9.3"
+lazy_static = "1.4.0"

--- a/vcf/src/headers.rs
+++ b/vcf/src/headers.rs
@@ -48,4 +48,44 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn can_parse_when_quoted_text_contains_comma_in_last_key_value_pair() {
+        let input = "##FORMAT=<abc=123,xyz=3125,sfh=\"1,574\">";
+        let header = Header::parse(input);
+
+        assert_eq!(
+            header,
+            Ok(
+                Header {
+                    key: "FORMAT",
+                    value: HeaderValue::Nested(HashMap::from([
+                        ("abc", "123"),
+                        ("xyz", "3125"),
+                        ("sfh", "1,574"),
+                    ])),
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn can_parse_when_quoted_text_contains_comma_in_first_key_value_pair() {
+        let input = "##FORMAT=<abc=\"1,233\",xyz=3125,sfh=157>";
+        let header = Header::parse(input);
+
+        assert_eq!(
+            header,
+            Ok(
+                Header {
+                    key: "FORMAT",
+                    value: HeaderValue::Nested(HashMap::from([
+                        ("abc", "1,233"),
+                        ("xyz", "3125"),
+                        ("sfh", "157"),
+                    ])),
+                }
+            )
+        );
+    }
 }

--- a/vcf/src/parse.rs
+++ b/vcf/src/parse.rs
@@ -24,6 +24,12 @@ impl<'src> HeaderValue<'src> {
                 re.captures_iter(pairs)
                     .map(|c| c.get(0).unwrap().as_str())
                     .map(|pair| pair.split_once('=').ok_or(ParseError))
+                    .map(
+                        |r| match r {
+                            Ok((k, v)) => Ok((k, v.trim_matches('\"'))),
+                            x => x,
+                        }
+                    )
                     .collect::<Result<HashMap<_, _>, _>>()
                     .map(HeaderValue::Nested)
             }

--- a/vcf/src/parse.rs
+++ b/vcf/src/parse.rs
@@ -17,7 +17,7 @@ impl<'src> Header<'src> {
 
 impl<'src> HeaderValue<'src> {
     pub fn parse(input: &'src str) -> Result<Self, ParseError> {
-        let re = Regex::new(r#"((?:[^,"]+|(?:"[^"]*"))+)"#).unwrap();
+        let re = Regex::new(r#"(?:[^,"]+|(?:"[^"]*"))+"#).unwrap();
         match input.strip_prefix('<').and_then(|input| input.strip_suffix('>')) {
             None => Ok(Self::Flat(input)),
             Some(pairs) => {

--- a/vcf/src/parse.rs
+++ b/vcf/src/parse.rs
@@ -17,6 +17,9 @@ impl<'src> Header<'src> {
 
 impl<'src> HeaderValue<'src> {
     pub fn parse(input: &'src str) -> Result<Self, ParseError> {
+        // Repeatedly match either non-comma/non-quote characters or blocks of text enclosed in
+        // quotes, until we can't, in which case we're either at a non-quote-enclosed comma or the
+        // end of the string.
         let re = Regex::new(r#"(?:[^,"]+|(?:"[^"]*"))+"#).unwrap();
         match input.strip_prefix('<').and_then(|input| input.strip_suffix('>')) {
             None => Ok(Self::Flat(input)),


### PR DESCRIPTION
This ensures that the text from nested headers is not split on commas that are enclosed in quotes.

In particular, it ensures that this line
```
##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
```
from the example in section 1.1 of [the specs](https://samtools.github.io/hts-specs/VCFv4.4.pdf) can be parsed.

Note that section 1.2 lists the comma as one of the special characters which should always be 'represented with the
capitalized percent encoding' when they are not used for their specific meaning. However, I assume this refers only to cases where they are not enclosed within quotes.